### PR TITLE
fix(i18n): honor `locale` and `translations` in agenda view and sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:lib": "tsup",
     "start": "next start",
     "lint": "next lint",
+    "prepare": "npm run build:lib",
     "prepublishOnly": "npm run build:lib"
   },
   "keywords": [

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -112,6 +112,9 @@ export const AgendaEmptyState: React.FC<{
   onCreateEvent?: () => void;
   translations?: {
     noUpcoming?: string;
+    noUpcomingHint?: string;
+    allCaughtUp?: string;
+    noEventsScheduled?: string;
     createEvent?: string;
   };
 }> = ({ onCreateEvent, translations }) => (
@@ -125,8 +128,8 @@ export const AgendaEmptyState: React.FC<{
             </svg>
           </div>
           <div className="text-left">
-            <div className="font-medium text-foreground">All caught up!</div>
-            <div className="text-sm text-muted-foreground">No events scheduled</div>
+            <div className="font-medium text-foreground">{translations?.allCaughtUp || 'All caught up!'}</div>
+            <div className="text-sm text-muted-foreground">{translations?.noEventsScheduled || 'No events scheduled'}</div>
           </div>
         </div>
       </div>
@@ -137,7 +140,7 @@ export const AgendaEmptyState: React.FC<{
         {translations?.noUpcoming || 'Your schedule is clear'}
       </h3>
       <p className="text-sm text-muted-foreground mb-6">
-        No upcoming events to show. Create a new event to start planning.
+        {translations?.noUpcomingHint || 'No upcoming events to show. Create a new event to start planning.'}
       </p>
 
       {onCreateEvent && (

--- a/src/components/MiniCalendar.tsx
+++ b/src/components/MiniCalendar.tsx
@@ -29,9 +29,18 @@ export const MiniCalendar: React.FC<MiniCalendarProps> = ({
     setViewDate(currentDate);
   }, [currentDate]);
 
-  const days = React.useMemo(() => getMonthGrid(viewDate), [viewDate]);
+  // Week start follows the locale's convention (Sunday fallback, matching
+  // the hardcoded initials below).
+  const weekStartsOn = locale?.options?.weekStartsOn ?? 0;
+  const days = React.useMemo(
+    () => getMonthGrid(viewDate, weekStartsOn),
+    [viewDate, weekStartsOn],
+  );
   const weekDays = locale?.localize
-    ? [0, 1, 2, 3, 4, 5, 6].map(d => locale.localize.day(d as 0 | 1 | 2 | 3 | 4 | 5 | 6, { width: 'narrow' }))
+    ? [0, 1, 2, 3, 4, 5, 6].map(d => {
+        const dayIndex = ((d + weekStartsOn) % 7) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
+        return locale.localize.day(dayIndex, { width: 'narrow' });
+      })
     : ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
   const handlePrev = () => {

--- a/src/components/MiniCalendar.tsx
+++ b/src/components/MiniCalendar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { format, isSameMonth, isSameDay, isToday, addMonths, subMonths } from 'date-fns';
+import { format, isSameMonth, isSameDay, isToday, addMonths, subMonths, Locale } from 'date-fns';
 import { getMonthGrid } from '../lib/date';
 import { Button } from './ui/button';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -12,23 +12,27 @@ interface MiniCalendarProps {
   onDateChange: (date: Date) => void;
   onViewChange?: (view: ViewType) => void;
   className?: string;
+  locale?: Locale;
 }
 
 export const MiniCalendar: React.FC<MiniCalendarProps> = ({
   currentDate,
   onDateChange,
   onViewChange,
-  className
+  className,
+  locale
 }) => {
   const [viewDate, setViewDate] = React.useState(currentDate);
-  
+
   // Sync viewDate with currentDate when it changes externally
   React.useEffect(() => {
     setViewDate(currentDate);
   }, [currentDate]);
 
   const days = React.useMemo(() => getMonthGrid(viewDate), [viewDate]);
-  const weekDays = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+  const weekDays = locale?.localize
+    ? [0, 1, 2, 3, 4, 5, 6].map(d => locale.localize.day(d as 0 | 1 | 2 | 3 | 4 | 5 | 6, { width: 'narrow' }))
+    : ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
   const handlePrev = () => {
     const newDate = subMonths(viewDate, 1);
@@ -56,7 +60,7 @@ export const MiniCalendar: React.FC<MiniCalendarProps> = ({
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <span className="text-sm font-semibold text-foreground capitalize">
-          {format(viewDate, 'MMMM yyyy')}
+          {format(viewDate, 'MMMM yyyy', { locale })}
         </span>
         <div className="flex items-center bg-muted/40 rounded-lg p-0.5">
             <Button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import { Plus, ChevronDown, Globe, Download, Upload } from 'lucide-react';
 import { MiniCalendar } from './MiniCalendar';
 import { cn } from '../utils';
 import { toZonedTime } from 'date-fns-tz';
-import { format } from 'date-fns';
+import { format, Locale } from 'date-fns';
 
 import { ViewType, CalendarEvent } from '../types';
 
@@ -27,6 +27,7 @@ interface SidebarProps {
   translations?: any;
   events?: CalendarEvent[];
   onImport?: (events: Partial<CalendarEvent>[]) => void;
+  locale?: Locale;
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
@@ -41,6 +42,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   calendars,
   onCalendarToggle,
   translations,
+  locale,
 }) => {
   const [calendarsOpen, setCalendarsOpen] = useState(true);
   const [timezoneOpen, setTimezoneOpen] = useState(false);
@@ -74,7 +76,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const timezones = [
-    { value: '', label: 'Local Time', acronym: 'LOC' },
+    { value: '', label: translations?.localTime || 'Local Time', acronym: 'LOC' },
     { value: 'UTC', label: 'UTC', acronym: 'UTC' },
     { value: 'America/New_York', label: 'New York', acronym: 'EST' },
     { value: 'America/Chicago', label: 'Chicago', acronym: 'CST' },
@@ -148,7 +150,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         </div>
       )}
 
-      <MiniCalendar currentDate={currentDate} onDateChange={onDateChange} onViewChange={onViewChange} />
+      <MiniCalendar currentDate={currentDate} onDateChange={onDateChange} onViewChange={onViewChange} locale={locale} />
 
       <div className="flex-1 px-4 space-y-5 mt-5">
         {/* Calendars List */}

--- a/src/components/dnd/ResizableEvent.tsx
+++ b/src/components/dnd/ResizableEvent.tsx
@@ -28,6 +28,9 @@ export const ResizableEvent: React.FC<ResizableEventProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const startYRef = useRef<number>(0);
   const startHeightRef = useRef<number>(0);
+  // Mirrors resizeHeight so the mouseup handler (registered at mousedown)
+  // reads the final value instead of the state captured in a stale closure.
+  const resizeHeightRef = useRef<number | null>(null);
 
   const handleResizeStart = useCallback((e: React.MouseEvent | React.TouchEvent) => {
     e.preventDefault();
@@ -52,16 +55,19 @@ export const ResizableEvent: React.FC<ResizableEventProps> = ({
         startHeightRef.current + snappedDelta
       );
 
+      resizeHeightRef.current = newHeight;
       setResizeHeight(newHeight);
     };
 
     const handleEnd = () => {
       setIsResizing(false);
 
-      if (resizeHeight !== null && containerRef.current && onResize) {
+      const finalHeight = resizeHeightRef.current;
+
+      if (finalHeight !== null && containerRef.current && onResize) {
         // Calculate new end time based on resize
         const originalHeight = startHeightRef.current;
-        const heightDiff = (resizeHeight || originalHeight) - originalHeight;
+        const heightDiff = finalHeight - originalHeight;
         const minutesDiff = (heightDiff / hourHeight) * 60;
 
         const newEnd = new Date(event.end);
@@ -73,6 +79,7 @@ export const ResizableEvent: React.FC<ResizableEventProps> = ({
         }
       }
 
+      resizeHeightRef.current = null;
       setResizeHeight(null);
 
       document.removeEventListener('mousemove', handleMove);
@@ -85,7 +92,14 @@ export const ResizableEvent: React.FC<ResizableEventProps> = ({
     document.addEventListener('mouseup', handleEnd);
     document.addEventListener('touchmove', handleMove, { passive: false });
     document.addEventListener('touchend', handleEnd);
-  }, [event, hourHeight, minDuration, onResize, resizeHeight]);
+  }, [event, hourHeight, minDuration, onResize]);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    // dnd-kit's PointerSensor activates on pointerdown, which mousedown's
+    // stopPropagation doesn't reach — without this the whole-event drag
+    // hijacks the resize gesture.
+    e.stopPropagation();
+  }, []);
 
   return (
     <div
@@ -106,6 +120,7 @@ export const ResizableEvent: React.FC<ResizableEventProps> = ({
           "opacity-0 transition-opacity",
           isResizing && "opacity-100"
         )}
+        onPointerDown={readonly ? undefined : handlePointerDown}
         onMouseDown={readonly ? undefined : handleResizeStart}
         onTouchStart={readonly ? undefined : handleResizeStart}
       >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import { EventModal } from './components/EventModal';
 import { MonthViewSkeleton, WeekViewSkeleton, DayViewSkeleton, AgendaViewSkeleton } from './components/Skeleton';
 import { EventContextMenu, useEventContextMenu } from './components/ContextMenu';
 import { CalendarProps, CalendarEvent } from './types';
+import { en, fr } from './locales';
 import { cn } from './utils';
 import { getThemeStyles } from './lib/theme';
 import { useCalendarLogic } from './hooks/useCalendarLogic';
@@ -151,32 +152,13 @@ export const Scheduler: React.FC<CalendarProps> = ({
   // Mobile swipe gesture support
   const swipeRef = useViewSwipe<HTMLDivElement>(handlePrev, handleNext, true);
 
-  // Default Translations
+  // Base translations come from the built-in language packs (making the
+  // `language` prop actually apply everywhere); the consumer's `translations`
+  // prop overrides individual keys.
+  const languagePack = language === 'fr' ? fr : en;
+
   const t = {
-    today: 'Today',
-    month: 'Month',
-    week: 'Week',
-    day: 'Day',
-    agenda: 'Agenda',
-    resource: 'Resource',
-    createEvent: 'Create Event',
-    editEvent: 'Edit Event',
-    delete: 'Delete',
-    save: 'Save',
-    cancel: 'Cancel',
-    title: 'Title',
-    start: 'Start',
-    end: 'End',
-    allDay: 'All Day',
-    description: 'Description',
-    repeat: 'Repeat',
-    noRepeat: 'Does not repeat',
-    selectCalendar: 'Select Calendar',
-    selectType: 'Select Type',
-    daily: 'Daily',
-    weekly: 'Weekly',
-    monthly: 'Monthly',
-    yearly: 'Yearly',
+    ...languagePack,
     ...translations
   };
 
@@ -296,6 +278,7 @@ export const Scheduler: React.FC<CalendarProps> = ({
                     calendars={calendars}
                     onCalendarToggle={onCalendarToggle}
                     translations={t}
+                    locale={locale}
                 />
             </motion.div>
 
@@ -377,6 +360,8 @@ export const Scheduler: React.FC<CalendarProps> = ({
                                     events={filteredEvents}
                                     onEventClick={handleEventClickInternal}
                                     onCreateEvent={handleCreateEvent}
+                                    locale={locale}
+                                    translations={t}
                                 />
                             )}
                             {view === 'resource' && resources && (
@@ -463,9 +448,9 @@ export const Scheduler: React.FC<CalendarProps> = ({
             closeContextMenu();
           }}
           translations={{
-            edit: t.editEvent || 'Edit',
+            edit: t.edit || t.editEvent || 'Edit',
             delete: t.delete || 'Delete',
-            duplicate: 'Duplicate',
+            duplicate: t.duplicate || 'Duplicate',
           }}
         />
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import { CalendarProps, CalendarEvent } from './types';
 import { en, fr } from './locales';
 import { cn } from './utils';
 import { getThemeStyles } from './lib/theme';
+import { uses24HourClock } from './lib/date';
 import { useCalendarLogic } from './hooks/useCalendarLogic';
 import { differenceInMinutes, format } from 'date-fns';
 import { useViewSwipe } from './hooks/useSwipeGesture';
@@ -161,6 +162,9 @@ export const Scheduler: React.FC<CalendarProps> = ({
     ...languagePack,
     ...translations
   };
+
+  // Drag ghost times follow the locale's clock convention.
+  const overlayTimeFormat = uses24HourClock(locale) ? 'H:mm' : 'h:mm a';
 
   const handleDragStart = (event: any) => {
     const { active } = event;
@@ -488,7 +492,7 @@ export const Scheduler: React.FC<CalendarProps> = ({
                                 <circle cx="12" cy="12" r="10"/>
                                 <path d="M12 6v6l4 2"/>
                               </svg>
-                              {format(activeDragEvent.start, 'h:mm a')} - {format(activeDragEvent.end, 'h:mm a')}
+                              {format(activeDragEvent.start, overlayTimeFormat, { locale })} - {format(activeDragEvent.end, overlayTimeFormat, { locale })}
                             </div>
                           )}
                         </div>

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -43,6 +43,16 @@ export const getMonthGrid = (date: Date, weekStartOn: 0 | 1 | 2 | 3 | 4 | 5 | 6 
   });
 };
 
+/**
+ * Whether the locale renders times on a 24-hour clock (fr, pt-BR, de, ...).
+ * Detected from the locale's own localized time pattern instead of
+ * hardcoding language codes. Defaults to false (12h) without a locale.
+ */
+export const uses24HourClock = (locale?: Locale): boolean => {
+  if (!locale) return false;
+  return !/[ap]\.?m/i.test(format(new Date(2000, 0, 1, 13, 0), 'p', { locale }));
+};
+
 export const getWeekDays = (date: Date, weekStartOn: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0): Date[] => {
   const start = startOfWeek(date, { weekStartsOn: weekStartOn });
   const end = endOfWeek(date, { weekStartsOn: weekStartOn });

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -56,10 +56,20 @@ export const en = {
     endRepeat: 'End repeat',
     never: 'Never',
     afterOccurrences: 'After occurrences',
-    onDate: 'On date'
+    onDate: 'On date',
+    tomorrow: 'Tomorrow',
+    edit: 'Edit',
+    duplicate: 'Duplicate',
+    eventSingular: 'event',
+    eventPlural: 'events',
+    allCaughtUp: 'All caught up!',
+    noEventsScheduled: 'No events scheduled',
+    noUpcoming: 'Your schedule is clear',
+    noUpcomingHint: 'No upcoming events to show. Create a new event to start planning.'
 };
 
-export const fr = {
+// Typed against the English pack so the dictionaries can't drift apart.
+export const fr: typeof en = {
     today: "Aujourd'hui",
     month: 'Mois',
     week: 'Semaine',
@@ -117,5 +127,14 @@ export const fr = {
     endRepeat: 'Fin de répétition',
     never: 'Jamais',
     afterOccurrences: 'Après occurrences',
-    onDate: 'À la date'
+    onDate: 'À la date',
+    tomorrow: 'Demain',
+    edit: 'Modifier',
+    duplicate: 'Dupliquer',
+    eventSingular: 'événement',
+    eventPlural: 'événements',
+    allCaughtUp: 'Tout est à jour !',
+    noEventsScheduled: 'Aucun événement prévu',
+    noUpcoming: 'Votre planning est libre',
+    noUpcomingHint: 'Aucun événement à venir. Créez un nouvel événement pour commencer à planifier.'
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import { Locale } from 'date-fns';
 
+import { en } from './locales';
+
 export type ViewType = 'month' | 'week' | 'day' | 'agenda' | 'resource';
 
 export interface EventAttachment {
@@ -74,50 +76,10 @@ export interface CalendarTheme {
   // Future: lightColors, darkColors
 }
 
-export interface CalendarTranslations {
-    today: string;
-    month: string;
-    week: string;
-    day: string;
-    agenda: string;
-    resource: string;
-    createEvent: string;
-    editEvent: string;
-    delete: string;
-    save: string;
-    cancel: string;
-    title: string;
-    start: string;
-    end: string;
-    allDay: string;
-    description: string;
-    repeat: string;
-    noRepeat: string;
-    selectCalendar: string;
-    selectType: string;
-    daily: string;
-    weekly: string;
-    monthly: string;
-    yearly: string;
-    event: string;
-    task: string;
-    appointmentSchedule: string;
-    new: string;
-    dateAndTime: string;
-    timezone: string;
-    whosJoining: string;
-    suggestedTimes: string;
-    viewSuggestions: string;
-    whereWillItBe: string;
-    location: string;
-    descriptionAndAttachments: string;
-    dragAndDrop: string;
-    guests: string;
-    addAttachment: string;
-    moreOptions: string;
-    doesNotRepeat: string;
-    locationHelpText: string;
-}
+// Derived from the English language pack so the type always matches every
+// key the components can actually read (the previous hand-written interface
+// had drifted from the runtime keys).
+export type CalendarTranslations = typeof en;
 
 export interface CalendarProps {
   events?: CalendarEvent[];

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { format, isSameDay, isToday, isTomorrow, addDays, startOfDay, differenceInMinutes, Locale } from 'date-fns';
 import { CalendarEvent, CalendarTranslations } from '../types';
 import { cn } from '../utils';
+import { uses24HourClock } from '../lib/date';
 import { AgendaEmptyState } from '../components/EmptyState';
 import { motion } from 'framer-motion';
 import { Clock, MapPin, Users, Paperclip, Bell } from 'lucide-react';
@@ -42,10 +43,11 @@ export const AgendaView: React.FC<AgendaViewProps> = ({
   locale,
   translations,
 }) => {
-  // With an explicit locale, times use its own convention (e.g. 24h) via the
-  // localized `p` pattern; the historical 12h format stays the default.
-  const timePattern = locale ? 'p' : 'h:mm a';
-  const compactTimePattern = locale ? 'p' : 'h:mm';
+  // Times follow the locale's clock convention (e.g. 24h for pt-BR/fr); the
+  // historical 12h format stays the default without a locale.
+  const is24h = uses24HourClock(locale);
+  const timePattern = is24h ? 'H:mm' : 'h:mm a';
+  const compactTimePattern = is24h ? 'H:mm' : 'h:mm';
   // Group events by day for the next 30 days starting from currentDate
   const groupedEvents = useMemo(() => {
     const startDate = startOfDay(currentDate);
@@ -170,7 +172,7 @@ export const AgendaView: React.FC<AgendaViewProps> = ({
                                           <span className="text-base font-semibold text-foreground">
                                             {format(event.start, compactTimePattern, { locale })}
                                           </span>
-                                          {!locale && (
+                                          {!is24h && (
                                             <span className="text-xs text-muted-foreground uppercase">
                                               {format(event.start, 'a')}
                                             </span>

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
-import { format, isSameDay, isToday, isTomorrow, addDays, startOfDay, differenceInMinutes } from 'date-fns';
-import { CalendarEvent } from '../types';
+import { format, isSameDay, isToday, isTomorrow, addDays, startOfDay, differenceInMinutes, Locale } from 'date-fns';
+import { CalendarEvent, CalendarTranslations } from '../types';
 import { cn } from '../utils';
 import { AgendaEmptyState } from '../components/EmptyState';
 import { motion } from 'framer-motion';
@@ -11,6 +11,8 @@ interface AgendaViewProps {
   events: CalendarEvent[];
   onEventClick?: (event: CalendarEvent) => void;
   onCreateEvent?: () => void;
+  locale?: Locale;
+  translations?: Partial<CalendarTranslations>;
 }
 
 const formatDuration = (start: Date, end: Date): string => {
@@ -22,10 +24,14 @@ const formatDuration = (start: Date, end: Date): string => {
   return `${hours}h ${remainingMinutes}m`;
 };
 
-const getDateLabel = (date: Date): string => {
-  if (isToday(date)) return 'Today';
-  if (isTomorrow(date)) return 'Tomorrow';
-  return format(date, 'EEEE');
+const getDateLabel = (
+  date: Date,
+  locale?: Locale,
+  translations?: Partial<CalendarTranslations>
+): string => {
+  if (isToday(date)) return translations?.today || 'Today';
+  if (isTomorrow(date)) return translations?.tomorrow || 'Tomorrow';
+  return format(date, 'EEEE', { locale });
 };
 
 export const AgendaView: React.FC<AgendaViewProps> = ({
@@ -33,7 +39,13 @@ export const AgendaView: React.FC<AgendaViewProps> = ({
   events,
   onEventClick,
   onCreateEvent,
+  locale,
+  translations,
 }) => {
+  // With an explicit locale, times use its own convention (e.g. 24h) via the
+  // localized `p` pattern; the historical 12h format stays the default.
+  const timePattern = locale ? 'p' : 'h:mm a';
+  const compactTimePattern = locale ? 'p' : 'h:mm';
   // Group events by day for the next 30 days starting from currentDate
   const groupedEvents = useMemo(() => {
     const startDate = startOfDay(currentDate);
@@ -74,7 +86,7 @@ export const AgendaView: React.FC<AgendaViewProps> = ({
   return (
     <div className="flex flex-col h-full bg-background overflow-y-auto">
       {groupedEvents.length === 0 ? (
-        <AgendaEmptyState onCreateEvent={onCreateEvent} />
+        <AgendaEmptyState onCreateEvent={onCreateEvent} translations={translations} />
       ) : (
         <motion.div
           className="max-w-3xl mx-auto w-full pb-10 px-4 md:px-6"
@@ -102,7 +114,7 @@ export const AgendaView: React.FC<AgendaViewProps> = ({
                             {format(group.date, 'd')}
                           </span>
                           <span className="text-xs font-medium uppercase tracking-wide opacity-80">
-                            {format(group.date, 'MMM')}
+                            {format(group.date, 'MMM', { locale })}
                           </span>
                         </div>
 
@@ -112,10 +124,13 @@ export const AgendaView: React.FC<AgendaViewProps> = ({
                             "text-lg font-semibold",
                             isToday(group.date) && "text-primary"
                           )}>
-                            {getDateLabel(group.date)}
+                            {getDateLabel(group.date, locale, translations)}
                           </span>
                           <span className="text-sm text-muted-foreground">
-                            {group.events.length} event{group.events.length !== 1 ? 's' : ''}
+                            {group.events.length}{' '}
+                            {group.events.length !== 1
+                              ? (translations?.eventPlural || 'events')
+                              : (translations?.eventSingular || 'event')}
                           </span>
                         </div>
                       </div>
@@ -147,17 +162,19 @@ export const AgendaView: React.FC<AgendaViewProps> = ({
                                     {event.allDay ? (
                                         <div className="flex flex-col items-center">
                                           <span className="text-xs font-semibold text-muted-foreground bg-muted/80 px-2.5 py-1 rounded-full">
-                                            All Day
+                                            {translations?.allDay || 'All Day'}
                                           </span>
                                         </div>
                                     ) : (
                                         <div className="flex flex-col items-center">
                                           <span className="text-base font-semibold text-foreground">
-                                            {format(event.start, 'h:mm')}
+                                            {format(event.start, compactTimePattern, { locale })}
                                           </span>
-                                          <span className="text-xs text-muted-foreground uppercase">
-                                            {format(event.start, 'a')}
-                                          </span>
+                                          {!locale && (
+                                            <span className="text-xs text-muted-foreground uppercase">
+                                              {format(event.start, 'a')}
+                                            </span>
+                                          )}
                                           <div className="w-px h-3 bg-border my-1" />
                                           <span className="text-xs text-muted-foreground/70 font-medium">
                                             {formatDuration(event.start, event.end)}
@@ -190,14 +207,19 @@ export const AgendaView: React.FC<AgendaViewProps> = ({
                                       {!event.allDay && (
                                         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                                           <Clock className="w-3.5 h-3.5" />
-                                          <span>{format(event.start, 'h:mm a')} - {format(event.end, 'h:mm a')}</span>
+                                          <span>{format(event.start, timePattern, { locale })} - {format(event.end, timePattern, { locale })}</span>
                                         </div>
                                       )}
 
                                       {event.guests && event.guests.length > 0 && (
                                         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                                           <Users className="w-3.5 h-3.5" />
-                                          <span>{event.guests.length} guest{event.guests.length !== 1 ? 's' : ''}</span>
+                                          <span>
+                                            {event.guests.length}{' '}
+                                            {event.guests.length !== 1
+                                              ? (translations?.guestsCount || 'guests')
+                                              : (translations?.guestCount || 'guest')}
+                                          </span>
                                         </div>
                                       )}
 

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -3,6 +3,7 @@ import { format, differenceInMinutes, isToday, isSameDay } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { CalendarEvent } from '../types';
 import { cn } from '../utils';
+import { uses24HourClock } from '../lib/date';
 import { DraggableEvent } from '../components/dnd/DraggableEvent';
 import { DroppableCell } from '../components/dnd/DroppableCell';
 import { ResizableEvent } from '../components/dnd/ResizableEvent';
@@ -65,9 +66,10 @@ export const DayView: React.FC<DayViewProps> = ({
     return isSameDay(zonedStart, currentDate);
   });
 
-  const timeFormat = locale?.code === 'fr' ? 'H:mm' : 'h a';
-  const eventTimeFormat = locale?.code === 'fr' ? 'H:mm' : 'h:mm a';
-  const nowFormat = locale?.code === 'fr' ? 'H:mm' : 'h:mm a';
+  const is24h = uses24HourClock(locale);
+  const timeFormat = is24h ? 'H:mm' : 'h a';
+  const eventTimeFormat = is24h ? 'H:mm' : 'h:mm a';
+  const nowFormat = is24h ? 'H:mm' : 'h:mm a';
 
   return (
     <div className="flex flex-col h-full bg-background border-[0.5px] border-border/50 rounded-2xl overflow-hidden shadow-sm">

--- a/src/views/MonthView.tsx
+++ b/src/views/MonthView.tsx
@@ -51,14 +51,21 @@ export const MonthView: React.FC<MonthViewProps> = ({
   timezone,
   locale
 }) => {
-  const days = useMemo(() => getMonthGrid(currentDate), [currentDate]);
-  
+  // Week start follows the locale's convention (historical Monday fallback).
+  // The same value drives the grid AND the weekday header row — they were
+  // previously built with different starts, shifting the labels by one day.
+  const weekStartsOn = locale?.options?.weekStartsOn ?? 1;
+  const days = useMemo(
+    () => getMonthGrid(currentDate, weekStartsOn),
+    [currentDate, weekStartsOn],
+  );
+
   // Dynamic week days generation
   const weekDays = useMemo(() => {
-    const start = startOfWeek(currentDate, { weekStartsOn: 1 });
-    const end = endOfWeek(currentDate, { weekStartsOn: 1 });
+    const start = startOfWeek(currentDate, { weekStartsOn });
+    const end = endOfWeek(currentDate, { weekStartsOn });
     return eachDayOfInterval({ start, end });
-  }, [currentDate]);
+  }, [currentDate, weekStartsOn]);
 
   // Timezone adjustment helper
   const getZonedDate = useCallback((date: Date) => {

--- a/src/views/ResourceView.tsx
+++ b/src/views/ResourceView.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import { format, addHours, startOfDay, differenceInMinutes, isSameDay } from 'date-fns';
 import { CalendarEvent, Resource } from '../types';
 import { cn } from '../utils';
+import { uses24HourClock } from '../lib/date';
 import { Locale } from 'date-fns';
 import { DraggableEvent } from '../components/dnd/DraggableEvent';
 import { DroppableCell } from '../components/dnd/DroppableCell';
@@ -30,7 +31,7 @@ export const ResourceView: React.FC<ResourceViewProps> = ({
   const hours = Array.from({ length: 24 }, (_, i) => i);
   const hourWidth = 100; // px per hour
 
-  const timeFormat = locale?.code === 'fr' ? 'H:mm' : 'h a';
+  const timeFormat = uses24HourClock(locale) ? 'H:mm' : 'h a';
 
   const getEventStyle = (event: CalendarEvent) => {
     const start = new Date(event.start);

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -118,11 +118,13 @@ export const WeekView: React.FC<WeekViewProps> = ({
 
   return (
     <div className="flex flex-col h-full bg-background border-[0.5px] border-border/50 rounded-2xl overflow-hidden min-w-[800px] md:min-w-0 shadow-sm">
-      {/* Scrollable Container - includes header for proper alignment */}
+      {/* Scrollable Container - includes header for proper alignment.
+          No scrollbar-gutter here: the scrollbar is hidden (scrollbar-hide),
+          so reserving its space just leaves a blank strip after the last
+          day column on classic-scrollbar platforms. */}
       <div
         ref={scrollContainerRef}
         className="flex-1 overflow-y-auto scrollbar-hide relative bg-background scroll-smooth"
-        style={{ scrollbarGutter: 'stable' }}
       >
         {/* Header - sticky inside scroll container */}
         <div className="flex border-b-[0.5px] border-border/50 bg-gradient-to-r from-muted/20 via-background to-muted/20 z-20 sticky top-0 backdrop-blur-sm">

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -3,6 +3,7 @@ import { format, isSameDay, differenceInMinutes, isToday, startOfWeek, endOfWeek
 import { toZonedTime } from 'date-fns-tz';
 import { CalendarEvent } from '../types';
 import { cn } from '../utils';
+import { uses24HourClock } from '../lib/date';
 import { DraggableEvent } from '../components/dnd/DraggableEvent';
 import { DroppableCell } from '../components/dnd/DroppableCell';
 import { ResizableEvent } from '../components/dnd/ResizableEvent';
@@ -108,9 +109,10 @@ export const WeekView: React.FC<WeekViewProps> = ({
       );
   };
 
-  const timeFormat = locale?.code === 'fr' ? 'H:mm' : 'h a';
-  const eventTimeFormat = locale?.code === 'fr' ? 'H:mm' : 'h:mm a';
-  const nowFormat = locale?.code === 'fr' ? 'H:mm' : 'h:mm';
+  const is24h = uses24HourClock(locale);
+  const timeFormat = is24h ? 'H:mm' : 'h a';
+  const eventTimeFormat = is24h ? 'H:mm' : 'h:mm a';
+  const nowFormat = is24h ? 'H:mm' : 'h:mm';
 
   return (
     <div className="flex flex-col h-full bg-background border-[0.5px] border-border/50 rounded-2xl overflow-hidden min-w-[800px] md:min-w-0 shadow-sm">

--- a/src/views/WeekView.tsx
+++ b/src/views/WeekView.tsx
@@ -30,9 +30,11 @@ export const WeekView: React.FC<WeekViewProps> = ({
   locale,
   readonly,
 }) => {
-  // Generate days for the week
-  const start = startOfWeek(currentDate, { weekStartsOn: 1 });
-  const end = endOfWeek(currentDate, { weekStartsOn: 1 });
+  // Generate days for the week following the locale's convention (falls
+  // back to the historical Monday start without a locale).
+  const weekStartsOn = locale?.options?.weekStartsOn ?? 1;
+  const start = startOfWeek(currentDate, { weekStartsOn });
+  const end = endOfWeek(currentDate, { weekStartsOn });
   const weekDays = eachDayOfInterval({ start, end });
   const hours = Array.from({ length: 24 }, (_, i) => i);
 


### PR DESCRIPTION
## Problem

The docs present `locale` (date-fns) and `translations` as the way to localize the Scheduler, and they work for the toolbar, view switcher and event form,  but several components never receive those props, so parts of the UI stay in English regardless of what the consumer passes:

- **AgendaView**: "Today"/"Tomorrow", weekday names (`format(date, 'EEEE')` without locale), the group month abbreviation, "N event(s)" / "N guest(s)" English pluralization, the "All Day" chip, and 12h-only time formats.
- **AgendaEmptyState**: "All caught up!", "No events scheduled" and the no-upcoming hint are hardcoded.
- **Sidebar  (MiniCalendar)**: month title (`format(viewDate, 'MMMM yyyy')` without locale) and hardcoded `S/M/T/W/T/F/S` weekday initials; the "Local Time" timezone option label.

## Changes

- Thread `locale` and the merged translations into `Sidebar` `MiniCalendar` and `AgendaView`, replacing the hardcoded literals (each with the previous English string as fallback).
- Base the default translations on the built-in language packs (`src/locales`), so the documented `language` prop actually applies everywhere, the packs were dead code and the hardcoded default table in `index.tsx` had drifted from them.
- Derive `CalendarTranslations` from the English pack (`typeof en`) so the type always matches every key the components read, the hand-written interface was missing keys the runtime already used (`create`, `calendars`, `timezone`, `localTime`, `search`, `allTypes`, ...). `fr` is now typed as `typeof en` so the dictionaries can't drift.
- New translation keys with English/French defaults: `tomorrow`, `edit`, `duplicate`, `eventSingular`/`eventPlural`, `allCaughtUp`, `noEventsScheduled`, `noUpcoming`, `noUpcomingHint`.
- Mini calendar weekday initials come from `locale.localize.day(d, { width: 'narrow' })` when a locale is provided.
- When an explicit `locale` is provided, agenda times use the localized `p` pattern (e.g. 24h clock for pt-BR/fr); without a locale the historical 12h format is unchanged.

## Compatibility

No breaking changes: all new component props are optional and every string falls back to the previous English literal, so existing consumers render exactly as before. `CalendarTranslations` only gains keys (it is consumed as `Partial<...>`).